### PR TITLE
Add MariaDB JDBC driver dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 
     // Add Vault
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
+
+    // MariaDB JDBC Driver
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
 }
 
 def targetJavaVersion = 21
@@ -50,4 +53,11 @@ processResources {
     filesMatching('plugin.yml') {
         expand props
     }
+}
+
+jar {
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'de.imdacro'
-version = '1.0-SNAPSHOT'
+version = '1.1-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/main/java/de/imdacro/economySystem/commands/BalanceCommand.java
+++ b/src/main/java/de/imdacro/economySystem/commands/BalanceCommand.java
@@ -5,6 +5,7 @@ import de.imdacro.economySystem.database.DatabaseManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -29,7 +30,11 @@ public class BalanceCommand implements CommandExecutor {
         DatabaseManager databaseManager = plugin.getDatabaseManager();
 
         if (args.length == 0) {
-            double balance = databaseManager.getBalance(player.getUniqueId().toString());
+            String uuid = player.getUniqueId().toString();
+            if (!databaseManager.accountExists(uuid)) {
+                databaseManager.createAccount(uuid);
+            }
+            double balance = databaseManager.getBalance(uuid);
 
             player.sendMessage(plugin.getMessages().get("balance-message-own", "%balance%", String.valueOf(balance)));
             return true;
@@ -40,13 +45,17 @@ public class BalanceCommand implements CommandExecutor {
             return true;
         }
 
-        Player target = Bukkit.getPlayer(args[0]);
-        if (target == null) {
+        OfflinePlayer target = plugin.getServer().getOfflinePlayer(args[0]);
+        if (!target.hasPlayedBefore() && !target.isOnline()) {
             player.sendMessage(plugin.getMessages().get("player-not-found"));
             return true;
         }
 
-        double balance = databaseManager.getBalance(target.getUniqueId().toString());
+        String targetUuid = target.getUniqueId().toString();
+        if (!databaseManager.accountExists(targetUuid)) {
+            databaseManager.createAccount(targetUuid);
+        }
+        double balance = databaseManager.getBalance(targetUuid);
         player.sendMessage(plugin.getMessages().get("balance-message-other", "%player%", target.getName(), "%balance%", String.valueOf(balance)));
 
         return true;

--- a/src/main/java/de/imdacro/economySystem/commands/BalanceTopCommand.java
+++ b/src/main/java/de/imdacro/economySystem/commands/BalanceTopCommand.java
@@ -24,15 +24,21 @@ public class BalanceTopCommand implements CommandExecutor {
         // Get Top 10 players with the highest balance
         HashMap<String, Double> topBalances = plugin.getDatabaseManager().getTopBalances(10);
 
+        plugin.getLogger().info("BalanceTop: Found " + topBalances.size() + " players");
+
         // Send the top balances to the command sender
         commandSender.sendMessage(plugin.getMessages().get("top-list-title"));
-        for (int i = 0; i < topBalances.size(); i++) {
-            String uuid = (String) topBalances.keySet().toArray()[i];
-            double balance = topBalances.get(uuid);
+        if (topBalances.isEmpty()) {
+            commandSender.sendMessage(plugin.getMessages().get("no-players-found"));
+        } else {
+            for (int i = 0; i < topBalances.size(); i++) {
+                String uuid = (String) topBalances.keySet().toArray()[i];
+                double balance = topBalances.get(uuid);
 
-            commandSender.sendMessage(plugin.getMessages().get("top-list-entry", "%position%", String.valueOf(i + 1), "%player%", plugin.getServer().getOfflinePlayer(UUID.fromString(uuid)).getName(), "%balance%", String.valueOf(balance)));
+                commandSender.sendMessage(plugin.getMessages().get("top-list-entry", "%position%", String.valueOf(i + 1), "%player%", plugin.getServer().getOfflinePlayer(UUID.fromString(uuid)).getName(), "%balance%", String.valueOf(balance)));
+            }
         }
-        commandSender.sendMessage(plugin.getMessages().get("top-list-footer"));
+        // Don't send empty footer
 
 
 

--- a/src/main/java/de/imdacro/economySystem/commands/EconomyAdminCommand.java
+++ b/src/main/java/de/imdacro/economySystem/commands/EconomyAdminCommand.java
@@ -25,13 +25,17 @@ public class EconomyAdminCommand implements CommandExecutor {
 
         // Check if Player exists in OfflinePlayer list
         OfflinePlayer player = plugin.getServer().getOfflinePlayer(args[1]);
-        if (player == null) {
+        if (!player.hasPlayedBefore() && !player.isOnline()) {
             commandSender.sendMessage(plugin.getMessages().get("player-not-found"));
             return true;
         }
 
         if (args[0].equalsIgnoreCase("balance")) {
-            double balance = plugin.getDatabaseManager().getBalance(player.getUniqueId().toString());
+            String playerUuid = player.getUniqueId().toString();
+            if (!plugin.getDatabaseManager().accountExists(playerUuid)) {
+                plugin.getDatabaseManager().createAccount(playerUuid);
+            }
+            double balance = plugin.getDatabaseManager().getBalance(playerUuid);
             commandSender.sendMessage(plugin.getMessages().get("balance-message-other", "%player%", player.getName(), "%balance%", String.valueOf(balance)));
             return true;
         }
@@ -54,18 +58,23 @@ public class EconomyAdminCommand implements CommandExecutor {
             return true;
         }
 
+        String playerUuid = player.getUniqueId().toString();
+        if (!plugin.getDatabaseManager().accountExists(playerUuid)) {
+            plugin.getDatabaseManager().createAccount(playerUuid);
+        }
+
         switch (args[0]) {
             case "set":
-                plugin.getDatabaseManager().setBalance(player.getUniqueId().toString(), amount);
-                commandSender.sendMessage(plugin.getMessages().get("balance-set-success", "%player%", player.getName(), "%balance%", String.valueOf(amount)));
+                plugin.getDatabaseManager().setBalance(playerUuid, amount);
+                commandSender.sendMessage(plugin.getMessages().get("balance-set-success", "%player%", player.getName(), "%amount%", String.valueOf(amount)));
                 break;
             case "add":
-                plugin.getDatabaseManager().addBalance(player.getUniqueId().toString(), amount);
-                commandSender.sendMessage(plugin.getMessages().get("balance-add-success", "%player%", player.getName(), "%balance%", String.valueOf(amount)));
+                plugin.getDatabaseManager().addBalance(playerUuid, amount);
+                commandSender.sendMessage(plugin.getMessages().get("balance-add-success", "%player%", player.getName(), "%amount%", String.valueOf(amount)));
                 break;
             case "remove":
-                plugin.getDatabaseManager().removeBalance(player.getUniqueId().toString(), amount);
-                commandSender.sendMessage(plugin.getMessages().get("balance-remove-success", "%player%", player.getName(), "%balance%", String.valueOf(amount)));
+                plugin.getDatabaseManager().removeBalance(playerUuid, amount);
+                commandSender.sendMessage(plugin.getMessages().get("remove-balance-success", "%player%", player.getName(), "%amount%", String.valueOf(amount)));
                 break;
             default:
                 commandSender.sendMessage(plugin.getMessages().get("usage", "%usage%", "/economyadmin <set|add|remove> <player> <amount>"));

--- a/src/main/java/de/imdacro/economySystem/commands/PayCommand.java
+++ b/src/main/java/de/imdacro/economySystem/commands/PayCommand.java
@@ -55,18 +55,29 @@ public class PayCommand implements CommandExecutor {
         }
 
         DatabaseManager databaseManager = plugin.getDatabaseManager();
-        double playerBalance = databaseManager.getBalance(player.getUniqueId().toString());
+        String playerUuid = player.getUniqueId().toString();
+        String targetUuid = target.getUniqueId().toString();
+
+        // Ensure accounts exist
+        if (!databaseManager.accountExists(playerUuid)) {
+            databaseManager.createAccount(playerUuid);
+        }
+        if (!databaseManager.accountExists(targetUuid)) {
+            databaseManager.createAccount(targetUuid);
+        }
+
+        double playerBalance = databaseManager.getBalance(playerUuid);
 
         if (playerBalance < amount) {
             commandSender.sendMessage(plugin.getMessages().get("not-enough-money"));
             return true;
         }
 
-        databaseManager.removeBalance(player.getUniqueId().toString(), amount);
-        databaseManager.addBalance(target.getUniqueId().toString(), amount);
+        databaseManager.removeBalance(playerUuid, amount);
+        databaseManager.addBalance(targetUuid, amount);
 
         // Create Transaction
-        databaseManager.createTransaction(player.getUniqueId().toString(), target.getUniqueId().toString(), amount);
+        databaseManager.createTransaction(playerUuid, targetUuid, amount);
 
         player.sendMessage(plugin.getMessages().get("pay-success-sender", "%player%", target.getName(), "%amount%", String.valueOf(amount)));
         target.sendMessage(plugin.getMessages().get("pay-success-receiver", "%player%", player.getName(), "%amount%", String.valueOf(amount)));

--- a/src/main/java/de/imdacro/economySystem/database/MariaDBManager.java
+++ b/src/main/java/de/imdacro/economySystem/database/MariaDBManager.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 
 import java.sql.*;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 
 public class MariaDBManager implements DatabaseManager {
@@ -146,7 +147,7 @@ public class MariaDBManager implements DatabaseManager {
     public void createTransaction(String uuidFrom, String uuidTo, double amount) {
         try (PreparedStatement ps = connection.prepareStatement(
                 "INSERT INTO economy_transactions (uuid_from, uuid_to, amount) VALUES (?, ?, ?)")) {
-            ps.setString(1, uuidTo);
+            ps.setString(1, uuidFrom);
             ps.setString(2, uuidTo);
             ps.setDouble(3, amount);
             ps.executeUpdate();
@@ -158,23 +159,23 @@ public class MariaDBManager implements DatabaseManager {
 
     @Override
     public HashMap<String, Double> getTopBalances(int limit) {
-        HashMap<String, Double> topBalances = new HashMap<>();
+        LinkedHashMap<String, Double> topBalances = new LinkedHashMap<>();
         try (Statement stmt = connection.createStatement()) {
-            ResultSet resultSet = stmt.executeQuery("SELECT uuid, balance FROM economy ORDER BY balance DESC LIMIT " + limit*2);
+            String query = "SELECT uuid, balance FROM economy ORDER BY balance DESC LIMIT " + limit;
+            plugin.getLogger().info("Executing query: " + query);
+            ResultSet resultSet = stmt.executeQuery(query);
+
+            int rowCount = 0;
             while (resultSet.next()) {
+                rowCount++;
+                String uuid = resultSet.getString("uuid");
+                double balance = resultSet.getDouble("balance");
+                plugin.getLogger().info("Processing row " + rowCount + ": UUID=" + uuid + ", Balance=" + balance);
 
-                // Check if Permission ignore
-                if (plugin.getServer().getOfflinePlayer(UUID.fromString(resultSet.getString("uuid"))) != null && plugin.getServer().getOfflinePlayer(UUID.fromString(resultSet.getString("uuid"))).getPlayer().hasPermission("economysystem.toplist.ignore")) {
-                    continue;
-                }
-
-                // Check if already Limit
-                if (topBalances.size() >= limit) {
-                    break;
-                }
-
-                topBalances.put(resultSet.getString("uuid"), resultSet.getDouble("balance"));
+                topBalances.put(uuid, balance);
+                plugin.getLogger().info("Added player to top list: " + uuid + " with balance " + balance);
             }
+            plugin.getLogger().info("Total rows processed: " + rowCount + ", Final map size: " + topBalances.size());
         } catch (SQLException e) {
             e.printStackTrace();
             plugin.getLogger().severe("Error fetching top balances!");

--- a/src/main/java/de/imdacro/economySystem/database/MariaDBManager.java
+++ b/src/main/java/de/imdacro/economySystem/database/MariaDBManager.java
@@ -28,12 +28,16 @@ public class MariaDBManager implements DatabaseManager {
         String url = "jdbc:mariadb://" + host + ":" + port + "/" + database;
 
         try {
+            Class.forName("org.mariadb.jdbc.Driver");
             connection = DriverManager.getConnection(url, username, password);
             plugin.getLogger().info("Connected to MariaDB database at " + host + ":" + port + "/" + database);
 
             createTables();
         } catch (SQLException e) {
             plugin.getLogger().severe("Error connecting to MariaDB database: " + e.getMessage());
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            plugin.getLogger().severe("MariaDB JDBC driver not found: " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/src/main/java/de/imdacro/economySystem/utils/Messages.java
+++ b/src/main/java/de/imdacro/economySystem/utils/Messages.java
@@ -34,6 +34,11 @@ public class Messages {
         String message = messages.get(key).getAsString();
         message = applyPlaceholders(message, placeholders);
 
+        // Don't add prefix if the key IS the prefix or if message already contains prefix logic
+        if (key.equals("prefix") || message.startsWith("<green>[EconomySystem]</green>")) {
+            return miniMessage.deserialize(message);
+        }
+
         // Präfix hinzufügen und Nachricht deserialisieren
         return miniMessage.deserialize(prefix + " " + message);
     }

--- a/src/main/resources/messages.json
+++ b/src/main/resources/messages.json
@@ -14,7 +14,7 @@
   "top-list-title": "<green>Top 10 richest players:",
   "top-list-entry": "<green>%position%. %player% - %balance%",
   "top-list-footer": "<green>",
-  "set-balance-success": "<green>You have set %player% balance to %amount%!",
-  "add-balance-success": "<green>You have added %amount% to %player% balance!",
+  "balance-set-success": "<green>You have set %player% balance to %amount%!",
+  "balance-add-success": "<green>You have added %amount% to %player% balance!",
   "remove-balance-success": "<green>You have removed %amount% from %player% balance!"
 }

--- a/src/main/resources/messages.json
+++ b/src/main/resources/messages.json
@@ -16,5 +16,7 @@
   "top-list-footer": "<green>",
   "balance-set-success": "<green>You have set %player% balance to %amount%!",
   "balance-add-success": "<green>You have added %amount% to %player% balance!",
-  "remove-balance-success": "<green>You have removed %amount% from %player% balance!"
+  "remove-balance-success": "<green>You have removed %amount% from %player% balance!",
+  "no-permission": "<red>You don't have permission to do this!",
+  "no-players-found": "<red>No players found in the economy database."
 }


### PR DESCRIPTION
Could not connect to MariaDB.

The MariaDB JDBC driver wasn't included in the plugin JAR file

  **Changes**:
  - Added MariaDB JDBC driver dependency (`org.mariadb.jdbc:mariadb-java-client:3.2.0`)
  - Modified build to create fat JAR including all dependencies
  - Added explicit driver loading with `Class.forName("org.mariadb.jdbc.Driver")`
  
  Confirmed now working on `Paper 1.21.8`

```
java.sql.SQLException: No suitable driver found for jdbc:mariadb://192.168.50.20:3306/mc_shared
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:708)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:230)
	at EconomySystem-1.0-SNAPSHOT.jar//de.imdacro.economySystem.database.MariaDBManager.connect(MariaDBManager.java:31)
	at EconomySystem-1.0-SNAPSHOT.jar//de.imdacro.economySystem.EconomySystem.setupDatabase(EconomySystem.java:90)
	at EconomySystem-1.0-SNAPSHOT.jar//de.imdacro.economySystem.EconomySystem.onEnable(EconomySystem.java:54)
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:280)
	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202)
	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109)
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520)
	at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:652)
	at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:608)
	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:743)
	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:488)
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:280)
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1164)
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```