### PR TITLE
Vault API: Fix ClassCastException in ReflectionVault

### DIFF
--- a/src/main/java/de/imdacro/economySystem/vault/ReflectionVault.java
+++ b/src/main/java/de/imdacro/economySystem/vault/ReflectionVault.java
@@ -1,6 +1,7 @@
 package de.imdacro.economySystem.vault;
 
 import de.imdacro.economySystem.EconomySystem;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.ServicesManager;
 import java.lang.reflect.*;
@@ -32,46 +33,44 @@ public class ReflectionVault {
             case "isEnabled":
               return true;
             case "hasAccount": {
-              String playerName = (String) args[0];
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
+              UUID id = getTargetUUID(args[0]);
+              if (id == null) return false;
               return plugin.getDatabaseManager().accountExists(id.toString());
             }
             case "createPlayerAccount": {
-              String playerName = (String) args[0];
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
+              UUID id = getTargetUUID(args[0]);
+              if (id == null) return false;
               plugin.getDatabaseManager().createAccount(id.toString());
               return true;
             }
             case "getBalance": {
-              String playerName = (String) args[0];
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
+              UUID id = getTargetUUID(args[0]);
+              if (id == null) return 0.0D;
               return plugin.getDatabaseManager().getBalance(id.toString());
             }
             case "has": {
-              String playerName = (String) args[0];
+              UUID id = getTargetUUID(args[0]);
+              if (id == null) return false;
               double amount = ((Number) args[1]).doubleValue();
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
               return plugin.getDatabaseManager().getBalance(id.toString()) >= amount;
             }
             case "withdrawPlayer": {
-              String playerName = (String) args[0];
+              UUID id = getTargetUUID(args[0]);
               double amount = ((Number) args[1]).doubleValue();
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
+              if (id == null) return createEconomyResponse(econRespClass, respTypeClass, amount, 0.0D, "FAILURE", "Player not found");
               plugin.getDatabaseManager().removeBalance(id.toString(), amount);
               plugin.getDatabaseManager().createTransaction(id.toString(), "VAULT", amount);
               double balance = plugin.getDatabaseManager().getBalance(id.toString());
-              Object response = createEconomyResponse(econRespClass, respTypeClass, amount, balance, "SUCCESS", "");
-              return response;
+              return createEconomyResponse(econRespClass, respTypeClass, amount, balance, "SUCCESS", "");
             }
             case "depositPlayer": {
-              String playerName = (String) args[0];
+              UUID id = getTargetUUID(args[0]);
               double amount = ((Number) args[1]).doubleValue();
-              UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();
+              if (id == null) return createEconomyResponse(econRespClass, respTypeClass, amount, 0.0D, "FAILURE", "Player not found");
               plugin.getDatabaseManager().addBalance(id.toString(), amount);
               plugin.getDatabaseManager().createTransaction("VAULT", id.toString(), amount);
               double balance = plugin.getDatabaseManager().getBalance(id.toString());
-              Object response = createEconomyResponse(econRespClass, respTypeClass, amount, balance, "SUCCESS", "");
-              return response;
+              return createEconomyResponse(econRespClass, respTypeClass, amount, balance, "SUCCESS", "");
             }
             default:
               Class<?> returnType = method.getReturnType();
@@ -95,6 +94,15 @@ public class ReflectionVault {
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  private UUID getTargetUUID(Object arg) {
+    if (arg instanceof OfflinePlayer) {
+      return ((OfflinePlayer) arg).getUniqueId();
+    } else if (arg instanceof String) {
+      return plugin.getServer().getOfflinePlayer((String) arg).getUniqueId();
+    }
+    return null;
   }
 
   private Object createEconomyResponse(Class<?> econRespClass, Class<?> respTypeClass, double amount, double balance, String respName, String errorMessage) throws Exception {


### PR DESCRIPTION
Hi! I am the developer of EconomyGUI (https://modrinth.com/plugin/economygui/versions).

Recently, we encountered a problem where my EconomyGUI plugin was crashing to the server that uses the EconomySystem, with the following error: `ClassCastException: org.bukkit.craftbukkit.entity.CraftPlayer cannot be cast to the java.lang.String class'. This disrupts the graphical menus and spoils the economic interactions of the players.

What causes the issue:
In your `ReflectionVault.java` class, when Vault API calls are hooked, the first argument is explicitly cast to a String: `String playerName = (String) args[0];`. 
However, modern versions of Vault and EssentialsX prefer using methods that pass an `OfflinePlayer` (or `Player`) object, while String-based Vault methods are deprecated. When my plugin or EssentialsX calls Vault passing a player object, your hook tries to cast `CraftPlayer` directly into `String`, causing the crash.

I would really appreciate it if you could fix this in an upcoming update so our plugins can run smoothly together without conflicts.

I have already prepared a quick fix for you. You can add a helper method to handle argument type checking in `ReflectionVault.java`:

```java
private java.util.UUID getTargetUUID(Object arg) {
    if (arg instanceof org.bukkit.OfflinePlayer) {
        return ((org.bukkit.OfflinePlayer) arg).getUniqueId();
    } else if (arg instanceof String) {
        return plugin.getServer().getOfflinePlayer((String) arg).getUniqueId();
    }
    return null;
}

```

Then, in your `switch (name)` block, replace the old UUID retrieval logic with the new method. For example:

Instead of:
String playerName = (String) args[0];
UUID id = plugin.getServer().getOfflinePlayer(playerName).getUniqueId();

You can use:
UUID id = getTargetUUID(args[0]);
if (id == null) return false; // or 0.0D depending on the method signature

This will make your Vault integration fully flexible and resolve the incompatibility. Thanks in advance for looking into this!

I attached the log from the bottom, and also attached the commit.
[log.txt](https://github.com/user-attachments/files/30206372/log.txt)
